### PR TITLE
Modifications to permit running on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ tests/.tests
 pytest_session.txt
 .cache/
 .pytest_cache
-.coverage
+.coverage*
 
 # Cython related file
 *.c

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.imsim-0.5.1:
+
+-------------
+0.5.1
+-------------
+
+* Add MacOS support.
+
 .. _lsst.ts.imsim-0.5.0:
 
 -------------

--- a/python/lsst/ts/imsim/closedLoopTask.py
+++ b/python/lsst/ts/imsim/closedLoopTask.py
@@ -23,6 +23,7 @@ import logging
 import os
 import shutil
 from copy import deepcopy
+from glob import glob
 
 import astropy
 import numpy as np
@@ -1188,7 +1189,9 @@ config.dataset_config.ref_dataset_name='ref_cat'
             )
 
         runProgram(
-            f"convertReferenceCatalog {catDir} {catConfigFilename} {skyFilename} &> {catLogFilename}"
+            f"convertReferenceCatalog {catDir} {catConfigFilename} {skyFilename}",
+            stdout=catLogFilename,
+            stderr=catLogFilename,
         )
 
         runProgram(
@@ -1210,9 +1213,10 @@ config.dataset_config.ref_dataset_name='ref_cat'
             Instrument name.
         """
         outputImgDir = self.imsimCmpt.outputImgDir
+        files = " ".join(glob(os.path.join(outputImgDir, "amp*")))
 
         if instName in ["lsst", "lsstfam"]:
-            runProgram(f"butler ingest-raws {butlerRootPath} {outputImgDir}/amp*")
+            runProgram(f"butler ingest-raws {butlerRootPath} {files}")
 
         runProgram(f"butler define-visits {butlerRootPath} lsst.obs.lsst.LsstCam")
 

--- a/python/lsst/ts/imsim/utils/utility.py
+++ b/python/lsst/ts/imsim/utils/utility.py
@@ -129,3 +129,40 @@ def getZkFromFile(zkFilePath):
         zk[key] = np.fromstring(val[0], sep=" ")
 
     return zk
+
+
+class ModifiedEnvironment:
+    """Context manager to temporarily modify shell environment with specified
+    overrides.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Dictionary of environment variables to override. Keys and values should
+        be type str, unless the value is None, in which case the environment
+        variable will be unset.
+    """
+
+    def __init__(self, **kwargs):
+        self._overrides = kwargs
+        self._originals = {}
+
+    def __enter__(self):
+        for key, value in self._overrides.items():
+            # Save original value if exists
+            if key in os.environ:
+                self._originals[key] = os.environ[key]
+
+            # Set new values or unset if new value is None
+            if value is None:
+                del os.environ[key]
+            else:
+                os.environ[key] = value
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for key in self._overrides:
+            # Restore original values, delete or keep as they are based on the original state
+            if key in self._originals:
+                os.environ[key] = self._originals[key]
+            else:
+                del os.environ[key]

--- a/tests/utils/test_utility.py
+++ b/tests/utils/test_utility.py
@@ -25,6 +25,7 @@ import unittest
 from lsst.afw import cameraGeom
 from lsst.obs.lsst import LsstCam
 from lsst.ts.imsim.utils.utility import (
+    ModifiedEnvironment,
     getCamera,
     getConfigDir,
     getModulePath,
@@ -64,3 +65,26 @@ class TestUtility(unittest.TestCase):
             os.path.join(getModulePath(), "tests", "testData", "opd", "opd.zer")
         )
         self.assertCountEqual(zkFromFile.keys(), [191, 195, 199, 203])
+
+    def testModifiedEnvironment(self):
+        # Test adding a new environment variable
+        self.assertNotIn("TEST_AOS_ROCKS_5772", os.environ)
+        with ModifiedEnvironment(TEST_AOS_ROCKS_5772="parrot"):
+            self.assertEqual(os.environ["TEST_AOS_ROCKS_5772"], "parrot")
+        self.assertNotIn("TEST_AOS_ROCKS_5772", os.environ)
+
+        # Test modifying an existing environment variable
+        self.assertNotIn("TEST_AOS_ROCKS_57721", os.environ)
+        os.environ["TEST_AOS_ROCKS_57721"] = "spam"
+        self.assertEqual(os.environ["TEST_AOS_ROCKS_57721"], "spam")
+        with ModifiedEnvironment(TEST_AOS_ROCKS_57721="eggs"):
+            self.assertEqual(os.environ["TEST_AOS_ROCKS_57721"], "eggs")
+        self.assertEqual(os.environ["TEST_AOS_ROCKS_57721"], "spam")
+
+        # Test unsetting an existing environment variable
+        with ModifiedEnvironment(TEST_AOS_ROCKS_57721=None):
+            self.assertNotIn("TEST_AOS_ROCKS_57721", os.environ)
+        self.assertEqual(os.environ["TEST_AOS_ROCKS_57721"], "spam")
+
+        # Clean up
+        del os.environ["TEST_AOS_ROCKS_57721"]


### PR DESCRIPTION
The biggest change is that now the ts_wep runProgram method won't automatically do shell processing for you.  So things like redirection and file globbing have to be done manually.  Hopefully that's considered a small price for enabling a new platform.

The other bizarre change I found necessary was to unset the KMP_INIT_AT_FORK environment variable when running ImSim.  Without this modification, the code would run but then freeze in a `np.linalg.lstsq` call within batoid_rubin.  I'm guessing this is some kind of variant of the bug reported [here](https://github.com/numpy/numpy/issues/11734).  What's doubly weird though is that the reason this variable gets set at all (at least on my system) is that importing sklearn adds it to the environment.  Hopefully this workaround doesn't impact linux, but I haven't tried running this way yet.