### PR TITLE
Tickets/DM-42470: fix modified galsim environment

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Install
         run: |
+          $CONDA/bin/conda install python=3.11
           $CONDA/bin/conda install -c lsstts -y ts-pre-commit-config">=0.9.2"
           $CONDA/bin/conda install -c conda-forge pre-commit -y
           $CONDA/bin/generate_pre_commit_conf --skip-pre-commit-install

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,7 +6,12 @@
 Version History
 ##################
 
+=======
+1.2.1
 -------------
+
+* Update KMP_INIT_FORK to start only on darwin.
+
 1.2.0
 -------------
 

--- a/python/lsst/ts/imsim/imsim_cmpt.py
+++ b/python/lsst/ts/imsim/imsim_cmpt.py
@@ -22,6 +22,7 @@
 __all__ = ["ImsimCmpt"]
 
 import os
+import sys
 from typing import Any
 
 import numpy as np
@@ -327,13 +328,20 @@ class ImsimCmpt:
         # this variable gets set when sklearn is imported, which happens inside
         # of ts_wep before ever getting to this method, so we can't just unset
         # it in the environment ahead of time.
-        with ModifiedEnvironment(KMP_INIT_AT_FORK=None):
-            if imsim_log_file == "":
-                runProgram(f"galsim {config_file_path}")
-            else:
-                runProgram(
-                    f"galsim {config_file_path} -l {os.path.join(self.output_dir, imsim_log_file)} -v 2"
-                )
+        if imsim_log_file == "":
+            cmd = f"galsim {config_file_path}"
+        else:
+            cmd = f"galsim {config_file_path} -l {os.path.join(self.output_dir, imsim_log_file)} -v 2"
+        # Disabling the KMP_INIT_AT_FORK env variable only for OSX.
+        # This line checks whether the platform identifies itself as OSX.
+        # For all other environments (eg. linux) this is not needed;
+        # and indeed was found to cause issues for mag=12 and brighter
+        # source on USDF.
+        if sys.platform.startswith("darwin"):
+            with ModifiedEnvironment(KMP_INIT_AT_FORK=None):
+                runProgram(cmd)
+        else:
+            runProgram(cmd)
 
     def write_yaml_and_run_imsim(
         self,


### PR DESCRIPTION
Set `KMP_INIT_AT_FORK` to be only used with OSX (`darwin`   platform).   Don't use it if any other platform is present. Tested on UWs epyc machine (`linux`) and USDF (`linux`).  