### PR TITLE
Change imSim camera name LsstComCam to LsstComCamSim.

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -7,6 +7,12 @@ Version History
 ##################
 
 -------------
+1.3.1
+-------------
+
+* Change imSim camera name LsstComCam to LsstComCamSim.
+
+-------------
 1.3.0
 -------------
 

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -11,6 +11,7 @@ Version History
 -------------
 
 * Change imSim camera name LsstComCam to LsstComCamSim.
+* Fix stamp size when using LSST_Silicon.
 
 -------------
 1.3.0

--- a/policy/config/input/telescope/lsstComCamLargePert.yaml
+++ b/policy/config/input/telescope/lsstComCamLargePert.yaml
@@ -1,5 +1,5 @@
 telescope:
-  camera: LsstComCam
+  camera: LsstComCamSim
   file_name:
     type: FormattedStr
     format: ComCam_%s.yaml

--- a/policy/config/input/telescope/lsstComCamNoPert.yaml
+++ b/policy/config/input/telescope/lsstComCamNoPert.yaml
@@ -1,5 +1,5 @@
 telescope:
-  camera: LsstComCam
+  camera: LsstComCamSim
   file_name:
     type: FormattedStr
     format: ComCam_%s.yaml

--- a/policy/config/output/lsstComCamDefault.yaml
+++ b/policy/config/output/lsstComCamDefault.yaml
@@ -7,7 +7,7 @@ output:
     mjd: *mjd
     seqnum: *seqnum
 
-  camera: LsstComCam
+  camera: LsstComCamSim
 
   exptime: $exptime
 

--- a/policy/config/stamp/lsstCamLsstSilicon.yaml
+++ b/policy/config/stamp/lsstCamLsstSilicon.yaml
@@ -1,4 +1,5 @@
 stamp:
+  size: 500
   type: LSST_Silicon
   det_name: "$det_name"
   world_pos:

--- a/policy/config/stamp/lsstCamLsstSiliconWithDiffraction.yaml
+++ b/policy/config/stamp/lsstCamLsstSiliconWithDiffraction.yaml
@@ -1,4 +1,5 @@
 stamp:
+  size: 500
   type: LSST_Silicon
   det_name: "$det_name"
   world_pos:

--- a/python/lsst/ts/imsim/closed_loop_task.py
+++ b/python/lsst/ts/imsim/closed_loop_task.py
@@ -775,7 +775,7 @@ class ClosedLoopTask:
         if cam_type in [CamType.LsstCam, CamType.LsstFamCam]:
             butler_inst_name = "Cam"
         elif cam_type == CamType.ComCam:
-            butler_inst_name = "ComCam"
+            butler_inst_name = "ComCamSim"
 
         return butler_inst_name
 

--- a/tests/testData/imsimConfig/imsimConfigLsstCam.yaml
+++ b/tests/testData/imsimConfig/imsimConfigLsstCam.yaml
@@ -274,6 +274,7 @@ psf:
 
 
 stamp:
+  size: 500
   type: LSST_Silicon
   det_name: "$det_name"
   world_pos:

--- a/tests/test_closed_loop_task.py
+++ b/tests/test_closed_loop_task.py
@@ -183,4 +183,4 @@ class TestclosedLoopTask(unittest.TestCase):
 
         self.assertEqual(lsstcam_str, "Cam")
         self.assertEqual(lsstfam_str, "Cam")
-        self.assertEqual(comcam_str, "ComCam")
+        self.assertEqual(comcam_str, "ComCamSim")


### PR DESCRIPTION
Based on updated project guidelines to keep simulated data distinct from real camera `LsstComCam` is now `LsstComCamSim` in `imSim`.