### PR TITLE
Tickets/DM-44021: fix default pointer names

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,11 @@
 ##################
 Version History
 ##################
+-------------
+1.5.4
+-------------
+
+* Fix default pointer names in _generate_images.
 
 -------------
 1.5.3

--- a/python/lsst/ts/imsim/closed_loop_task.py
+++ b/python/lsst/ts/imsim/closed_loop_task.py
@@ -616,9 +616,9 @@ class ClosedLoopTask:
             if cam_type == CamType.LsstCam:
                 default_pointer = "lsstCamDefaultPointer.yaml"
             elif cam_type == CamType.LsstFamCam:
-                default_pointer = "lsstFamCamDefaultPointer.yaml"
+                default_pointer = "lsstFamNoPertPointer.yaml"
             elif cam_type == CamType.ComCam:
-                default_pointer = "lsstComCamDefaultPointer.yaml"
+                default_pointer = "lsstComCamNoPertPointer.yaml"
             imsim_config_pointer_file = os.path.join(get_config_dir(), default_pointer)
 
         base_config_yaml = self.imsim_cmpt.assemble_config_yaml(


### PR DESCRIPTION
Fixing `default_pointer` in `closed_loop_task.py` to correspond to existing filenames.